### PR TITLE
fetchFromGitHub is much faster than fetchgit

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,13 +1,14 @@
 {
   nixpkgs ?
     let
-      inherit (import <nixpkgs> {}) fetchgit;
+      inherit (import <nixpkgs> {}) fetchFromGitHub;
     in
       import
-        (fetchgit {
-           url = "git://github.com/NixOS/nixpkgs.git";
-           sha256 = "ccf2d010ad246e1bb1a7c8303174d9bac631981874c560b451468a841d0e24c4";
-           rev = "7475728593a49f09c4b7b959b15513aee38ab4b4";
+        (fetchFromGitHub {
+          owner = "NixOS";
+          repo = "nixpkgs";
+          sha256 = "0camjjd9mnanmqfll08f9whzxxvvw8md0rwlq65xyvsd0cg7r3li";
+          rev = "7475728593a49f09c4b7b959b15513aee38ab4b4";
          }) {}
   , compiler ? "ghc801"
 }:
@@ -25,16 +26,18 @@ let
       comonad = pkgs.haskell.lib.doJailbreak (pkgs.haskell.lib.dontCheck super.comonad);
       bifunctors = pkgs.haskell.lib.dontCheck (pkgs.haskell.lib.doJailbreak super.bifunctors);
       product-profunctors = pkgs.haskell.lib.overrideCabal super.product-profunctors (drv: {
-        src = pkgs.fetchgit {
-          url = git://github.com/ocharles/product-profunctors;
-          sha256 = "5ec18644e1e2166f7616bb28db3efe2bbee93883f3dfececc9da870f8c3cf734";
+        src = pkgs.fetchFromGitHub {
+          owner = "ocharles";
+          repo = "product-profunctors";
+          sha256 = "0d7p7j60z1ysr7nfrpzkhcwfkgibzqzdna5v2rv6y5p2w528dhay";
           rev = "5d9a8bd7ffcebab4083cc30d2b185a22d16d3dea";
         };
       });
       opaleye = pkgs.haskell.lib.doJailbreak (pkgs.haskell.lib.overrideCabal super.opaleye (drv: {
-        src = pkgs.fetchgit {
-          url = git://github.com/ocharles/haskell-opaleye;
-          sha256 = "e0150d106966c9bc34a2051d693f785acd549eb9f18bde2fcc076615ff3b55d8";
+        src = pkgs.fetchFromGitHub {
+          owner = "ocharles";
+          repo = "haskell-opaleye";
+          sha256 = "1vyvnqg3ik1v37gfg409maaviq8ggvyf2cnbw01nb3imj3n0f0d8";
           rev = "0234a162b242254ff0c44b642654a250087d6195";
         };
       }));


### PR DESCRIPTION
https://nixos.org/nixpkgs/manual/#sec-sources suggests using `fetchFromGitHub` in place of `fetchgit`.
