### PR TITLE
Naive first implementation of additional comparison operators

### DIFF
--- a/src/Opaleye/TF.hs
+++ b/src/Opaleye/TF.hs
@@ -25,7 +25,7 @@ module Opaleye.TF
          ExtractSchema, TableName, Column(..), PGNull(..), PGDefault(..),
 
          -- * Querying tables
-         queryTable, queryBy, queryOnto, Expr, select, leftJoin, restrict, (==.), (||.), ilike, isNull, not,
+         queryTable, queryBy, queryOnto, Expr, select, leftJoin, restrict, (==.), (/=.), (<.), (<=.), (>.), (>=.),(||.), ilike, isNull, not,
          filterQuery, asc, desc, orderNulls, OrderNulls(..), orderBy, Op.limit, Op.offset,
 
          -- * Inserting data
@@ -318,10 +318,40 @@ Expr a ==. Expr b =
   case Op.Column a Op..== Op.Column b of
     Op.Column c -> Expr c
 
+-- | The PostgreSQL @!=@ or @<>@ operator.
+(/=.) :: Expr a -> Expr a -> Expr 'PGBoolean
+Expr a /=. Expr b =
+  case Op.Column a Op../= Op.Column b of
+    Op.Column c -> Expr c
+
 -- | The PostgreSQL @OR@ operator.
 (||.) :: Expr a -> Expr a -> Expr 'PGBoolean
 Expr a ||. Expr b =
   case Op.Column a Op..|| Op.Column b of
+    Op.Column c -> Expr c
+
+-- | The PostgreSQL @<@ operator.
+(<.) :: Expr a -> Expr a -> Expr 'PGBoolean
+Expr a <. Expr b =
+  case Op.binOp Op.OpLt (Op.Column a) (Op.Column b) of
+    Op.Column c -> Expr c
+
+-- | The PostgreSQL @<=@ operator.
+(<=.) :: Expr a -> Expr a -> Expr 'PGBoolean
+Expr a <=. Expr b =
+  case Op.binOp Op.OpLtEq (Op.Column a) (Op.Column b) of
+    Op.Column c -> Expr c
+
+-- | The PostgreSQL @>@ operator.
+(>.) :: Expr a -> Expr a -> Expr 'PGBoolean
+Expr a >. Expr b =
+  case Op.binOp Op.OpGt (Op.Column a) (Op.Column b) of
+    Op.Column c -> Expr c
+
+-- | The PostgreSQL @>@ operator.
+(>=.) :: Expr a -> Expr a -> Expr 'PGBoolean
+Expr a >=. Expr b =
+  case Op.binOp Op.OpGtEq (Op.Column a) (Op.Column b) of
     Op.Column c -> Expr c
 
 -- | The PostgreSQL @ILIKE@ operator.
@@ -343,7 +373,12 @@ not (Expr a) =
     Op.Column b -> Expr b
 
 infix 4 ==.
+infix 4 /=.
 infixr 2 ||.
+infix 4 <.
+infix 4 <=.
+infix 4 >.
+infix 4 >=.
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
More type-safety may be desirable; E.g. Opaleye uses a `PGOrd` typeclass to enforce the requirement that postgres types be ordered. As far as I can tell the postgres manual does not appear to clarify which types are and which types (if any) are not comparable.

> Comparison operators are available for all relevant data types.

http://www.postgresql.org/docs/9.5/static/functions-comparison.html#FUNCTIONS-COMPARISON-TABLE
